### PR TITLE
fix: update config name and flags for binary

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,5 +39,5 @@ $ juju config parca-k8s memory-storage-limit=8192
 If you wish to enable the **experimental** storage persistence, you can do as such:
 
 ```bash
-$ juju config parca-k8s storage-persist=true
+$ juju config parca-k8s enable-persistence=true
 ```

--- a/config.yaml
+++ b/config.yaml
@@ -1,5 +1,5 @@
 options:
-  storage-persist:
+  enable-persistence:
     description: |
       Do not store profiles in memory, persist to disk. Location for persistence is '/var/lib/parca'
     type: boolean
@@ -9,6 +9,6 @@ options:
     description: |
       When storing profiles in memory, configure the in-memory storage limit, specified in MB.
 
-      Does nothing if storage-persist is True.
+      Does nothing if enable-persistence is True.
     type: int
     default: 4096

--- a/lib/charms/parca/v0/parca_config.py
+++ b/lib/charms/parca/v0/parca_config.py
@@ -31,7 +31,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 4
+LIBPATCH = 5
 
 
 DEFAULT_BIN_PATH = "/parca"
@@ -57,14 +57,12 @@ def parca_command_line(
     cmd = [str(bin_path), f"--config-path={config_path}"]
 
     # Render the template files with the correct values
-    if app_config["storage-persist"]:
+    if app_config["enable-persistence"]:
         # Add the correct command line options for disk persistence
-        cmd.append("--storage-in-memory=false")
-        cmd.append("--storage-persist")
+        cmd.append("--enable-persistence")
         cmd.append(f"--storage-path={profile_path}")
     else:
         limit = app_config["memory-storage-limit"] * 1048576
-        cmd.append("--storage-in-memory=true")
         cmd.append(f"--storage-active-memory={limit}")
 
     return " ".join(cmd)

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -22,7 +22,7 @@ resources:
     type: oci-image
     description: OCI image for parca
     # Included for simplicity in integration tests
-    upstream-source: ghcr.io/parca-dev/parca:main-790294ac
+    upstream-source: ghcr.io/parca-dev/parca:main-f6b9dba6
 
 storage:
   profiles:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -23,7 +23,7 @@ DEFAULT_PLAN = {
             "summary": "parca",
             "startup": "enabled",
             "override": "replace",
-            "command": "/parca --config-path=/etc/parca/parca.yaml --storage-in-memory=true --storage-active-memory=4294967296",
+            "command": "/parca --config-path=/etc/parca/parca.yaml --storage-active-memory=4294967296",
         }
     }
 }
@@ -66,13 +66,13 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(self.harness.get_workload_version(), "v0.12.0")
 
     def test_config_changed_container_not_ready(self):
-        self.harness.update_config({"storage-persist": False, "memory-storage-limit": 1024})
+        self.harness.update_config({"enable-persistence": False, "memory-storage-limit": 1024})
         self.assertEqual(self.harness.charm.unit.status, WaitingStatus("waiting for container"))
 
     def test_config_changed_container_ready(self):
         self.harness.container_pebble_ready("parca")
         self.harness.set_can_connect("parca", True)
-        self.harness.update_config({"storage-persist": False, "memory-storage-limit": 1024})
+        self.harness.update_config({"enable-persistence": False, "memory-storage-limit": 1024})
         self.assertEqual(self.harness.charm.unit.status, ActiveStatus())
 
     def test_configure(self):
@@ -102,28 +102,28 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(DEFAULT_PLAN, self.harness.charm._pebble_layer.to_dict())
 
     def test_parca_pebble_layer_adjusted_memory(self):
-        self.harness.update_config({"storage-persist": False, "memory-storage-limit": 1024})
+        self.harness.update_config({"enable-persistence": False, "memory-storage-limit": 1024})
         expected = {
             "services": {
                 "parca": {
                     "summary": "parca",
                     "startup": "enabled",
                     "override": "replace",
-                    "command": "/parca --config-path=/etc/parca/parca.yaml --storage-in-memory=true --storage-active-memory=1073741824",
+                    "command": "/parca --config-path=/etc/parca/parca.yaml --storage-active-memory=1073741824",
                 }
             }
         }
         self.assertEqual(expected, self.harness.charm._pebble_layer.to_dict())
 
     def test_parca_pebble_layer_storage_persist(self):
-        self.harness.update_config({"storage-persist": True, "memory-storage-limit": 1024})
+        self.harness.update_config({"enable-persistence": True, "memory-storage-limit": 1024})
         expected = {
             "services": {
                 "parca": {
                     "summary": "parca",
                     "startup": "enabled",
                     "override": "replace",
-                    "command": "/parca --config-path=/etc/parca/parca.yaml --storage-in-memory=false --storage-persist --storage-path=/var/lib/parca",
+                    "command": "/parca --config-path=/etc/parca/parca.yaml --enable-persistence --storage-path=/var/lib/parca",
                 }
             }
         }


### PR DESCRIPTION
Upstream changes to the flags in the snap https://github.com/parca-dev/parca/pull/1540. Changes reflect the updates to ensure the snap functions correctly. Includes a change to the charm config option name