### PR TITLE
fix: replan pebble when updating charm config

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -96,6 +96,7 @@ class ParcaOperatorCharm(CharmBase):
 
         # Try to configure Parca
         if self.container.can_connect():
+            self.container.add_layer("parca", self._pebble_layer, combine=True)
             self._configure(scrape_config)
             self.unit.status = ActiveStatus()
         else:


### PR DESCRIPTION
Due to my carelessness - the config-changed handler wasn't actually applying the new pebble plan when setting config options.

Updated so this happens, and added some tests to make sure.