### PR TITLE
build: update linting tooling to use ruff

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,28 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["config:base", ":disableDependencyDashboard"],
+  "extends": [
+    "config:base",
+    ":disableDependencyDashboard",
+    ":automergeDigest",
+    ":automergeMinor",
+    ":rebaseStalePrs",
+    ":semanticCommits",
+    ":semanticCommitScope(deps)",
+    "docker:pinDigests",
+    "helpers:pinGitHubActionDigests",
+    "regexManagers:dockerfileVersions"
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": ["^renovatebot/github-action"],
+      "schedule": ["weekly"]
+    },
+    {
+      "matchPaths": ["tox.ini"],
+      "groupName": "testing deps",
+      "schedule": ["weekly"]
+    }
+  ],
   "regexManagers": [
     {
       "fileMatch": ["tox.ini"],

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,15 +21,25 @@ target-version = ["py38"]
 profile = "black"
 
 # Linting tools configuration
-[tool.flake8]
-max-line-length = 99
-max-doc-length = 99
+[tool.ruff]
+line-length = 99
+select = ["E", "W", "F", "C", "N", "D"]
+extend-ignore = [
+    "D203",
+    "D204",
+    "D213",
+    "D215",
+    "D400",
+    "D404",
+    "D406",
+    "D407",
+    "D408",
+    "D409",
+    "D413",
+]
+ignore = ["E501", "D107"]
+extend-exclude = ["__pycache__", "*.egg_info"]
+per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
+
+[tool.ruff.mccabe]
 max-complexity = 10
-exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
-select = ["E", "W", "F", "C", "N", "R", "D", "H"]
-# Ignore W503, E501 because using black creates errors with this
-# Ignore D107 Missing docstring in __init__
-ignore = ["W503", "E501", "D107"]
-# D100, D101, D102, D103: Ignore missing docstrings in tests
-per-file-ignores = ["tests/*:D100,D101,D102,D103,D104"]
-docstring-convention = "google"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,13 +17,10 @@ log_cli_level = "INFO"
 line-length = 99
 target-version = ["py38"]
 
-[tool.isort]
-profile = "black"
-
 # Linting tools configuration
 [tool.ruff]
 line-length = 99
-select = ["E", "W", "F", "C", "N", "D"]
+select = ["E", "W", "F", "C", "N", "D", "I001"]
 extend-ignore = [
     "D203",
     "D204",

--- a/src/charm.py
+++ b/src/charm.py
@@ -14,10 +14,7 @@ from charms.parca.v0.parca_config import (
     parca_command_line,
     parse_version,
 )
-from charms.parca.v0.parca_scrape import (
-    ProfilingEndpointConsumer,
-    ProfilingEndpointProvider,
-)
+from charms.parca.v0.parca_scrape import ProfilingEndpointConsumer, ProfilingEndpointProvider
 from charms.prometheus_k8s.v0.prometheus_scrape import MetricsEndpointProvider
 from charms.traefik_k8s.v1.ingress import IngressPerAppRequirer
 from lightkube.models.core_v1 import ServicePort

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -9,11 +9,10 @@ from uuid import uuid4
 
 import ops.testing
 import yaml
+from charm import ParcaOperatorCharm
 from ops.model import ActiveStatus, WaitingStatus
 from ops.pebble import ExecError
 from ops.testing import Harness
-
-from charm import ParcaOperatorCharm
 
 ops.testing.SIMULATE_CAN_CONNECT = True
 

--- a/tox.ini
+++ b/tox.ini
@@ -7,12 +7,12 @@ envlist = fmt, lint, unit
 src_path = {toxinidir}/src/
 tst_path = {toxinidir}/tests/
 lib_path = {toxinidir}/lib/charms/parca-k8s/
-all_path = {[vars]src_path} {[vars]tst_path}  
+all_path = {[vars]src_path} {[vars]tst_path}
 
 [testenv]
 setenv =
   PYTHONPATH = {toxinidir}:{toxinidir}/lib:{[vars]src_path}
-  PYTHONBREAKPOINT=ipdb.set_trace
+  PYTHONBREAKPOINT=pdb.set_trace
   PY_COLORS=1
 passenv =
   PYTHONPATH
@@ -22,60 +22,74 @@ passenv =
 [testenv:fmt]
 description = Apply coding style standards to code
 deps =
-    black
-    isort
+    # renovate: datasource=pypi
+    black==22.10.0
+    # renovate: datasource=pypi
+    ruff==0.0.138
 commands =
-    isort {[vars]all_path}
+    ruff --fix {[vars]all_path}
     black {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
 deps =
-    black
-    flake8
-    flake8-docstrings
-    flake8-copyright
-    flake8-builtins
-    pyproject-flake8
-    pep8-naming
-    isort
-    codespell
+    # renovate: datasource=pypi
+    black==22.10.0
+    # renovate: datasource=pypi
+    ruff==0.0.138
+    # renovate: datasource=pypi
+    codespell==2.2.2
 commands =
     # uncomment the following line if this charm owns a lib
     ; codespell {[vars]lib_path}
-    codespell {toxinidir}/. --skip {toxinidir}/.git --skip {toxinidir}/.tox \
-      --skip {toxinidir}/build --skip {toxinidir}/lib --skip {toxinidir}/venv \
-      --skip {toxinidir}/.mypy_cache --skip {toxinidir}/icon.svg
-    # pflake8 wrapper supports config from pyproject.toml
-    pflake8 {[vars]all_path}
-    isort --check-only --diff {[vars]all_path}
+    codespell {toxinidir}/. \
+        --skip {toxinidir}/.git \
+        --skip {toxinidir}/.tox \
+        --skip {toxinidir}/build \
+        --skip {toxinidir}/lib \
+        --skip {toxinidir}/venv \
+        --skip {toxinidir}/.mypy_cache \
+        --skip {toxinidir}/icon.svg
+    
+    ruff {[vars]all_path}
     black --check --diff {[vars]all_path}
 
 [testenv:unit]
 description = Run unit tests
 deps =
+    -r{toxinidir}/requirements.txt
     # renovate: datasource=pypi
     pytest==7.1.0
     # renovate: datasource=pypi
     coverage[toml]==6.5.0
-    -r{toxinidir}/requirements.txt
 commands =
     coverage run --source={[vars]src_path} \
-        -m pytest --ignore={[vars]tst_path}integration -v --tb native -s {posargs}
+                 -m pytest \
+                 --ignore={[vars]tst_path}integration \
+                 --tb native \
+                 -v \
+                 -s \
+                 {posargs}
     coverage report
-
 
 [testenv:integration]
 description = Run integration tests
 deps =
-    juju
-    pytest
-    pytest-operator
-    tenacity
-    requests
     -r{toxinidir}/requirements.txt
+    # renovate: datasource=pypi
+    juju==3.0.4
+    # renovate: datasource=pypi
+    pytest==7.2.0
+    # renovate: datasource=pypi
+    pytest-operator==0.22.0
+    # renovate: datasource=pypi
+    tenacity==8.1.0
+    # renovate: datasource=pypi
+    requests==2.28.1
 commands =
-    pytest -v --tb native -s \
-        --ignore={[vars]tst_path}unit \
-        --log-cli-level=INFO \
-        {posargs}
+    pytest -v \
+           -s \
+           --tb native \
+           --ignore={[vars]tst_path}unit \
+           --log-cli-level=INFO \
+           {posargs}


### PR DESCRIPTION
Flake8 and pyproject-flake8 seem to be increasingly unstable and causing issues in CI. Move to `ruff`, replacing `isort`, `flake8-*` 

Driveby to pin versions and rely on renovate to update them