### PR TITLE
feat: implement external parca store relation

### DIFF
--- a/lib/charms/parca/v0/parca_config.py
+++ b/lib/charms/parca/v0/parca_config.py
@@ -31,7 +31,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 5
+LIBPATCH = 6
 
 
 DEFAULT_BIN_PATH = "/parca"
@@ -40,11 +40,12 @@ DEFAULT_PROFILE_PATH = "/var/lib/parca"
 
 
 def parca_command_line(
-    app_config: dict,
+    app_config: dict = None,
     *,
     bin_path: str = DEFAULT_BIN_PATH,
     config_path: str = DEFAULT_CONFIG_PATH,
     profile_path: str = DEFAULT_PROFILE_PATH,
+    store_config: dict = None,
 ) -> str:
     """Generate a valid Parca command line.
 
@@ -53,17 +54,35 @@ def parca_command_line(
         bin_path: Path to the Parca binary to be started.
         config_path: Path to the Parca YAML configuration file.
         profile_path: Path to profile storage directory.
+        store_config: Configuration to send profiles to a remote store
     """
     cmd = [str(bin_path), f"--config-path={config_path}"]
 
     # Render the template files with the correct values
-    if app_config["enable-persistence"]:
+
+    if app_config.get("enable-persistence", None):
         # Add the correct command line options for disk persistence
         cmd.append("--enable-persistence")
         cmd.append(f"--storage-path={profile_path}")
     else:
         limit = app_config["memory-storage-limit"] * 1048576
         cmd.append(f"--storage-active-memory={limit}")
+
+    if store_config is not None:
+        store_config_args = []
+
+        if addr := store_config.get("remote-store-address", None):
+            store_config_args.append(f"--store-address={addr}")
+
+        if token := store_config.get("remote-store-bearer-token", None):
+            store_config_args.append(f"--bearer-token={token}")
+
+        if insecure := store_config.get("remote-store-insecure", None):
+            store_config_args.append(f"--insecure={insecure}")
+
+        if store_config_args:
+            store_config_args.append("--mode=scraper-only")
+            cmd += store_config_args
 
     return " ".join(cmd)
 
@@ -95,7 +114,7 @@ class ParcaConfig:
         }
 
     def to_dict(self) -> dict:
-        """Returns the Parca config as a Python dictionary."""
+        """Return the Parca config as a Python dictionary."""
         return self._config
 
     def __str__(self) -> str:

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -37,6 +37,8 @@ requires:
   ingress:
     interface: ingress
     limit: 1
+  external-parca-store-endpoint:
+    interface: parca_store
 
 provides:
   grafana-dashboard:

--- a/src/parca.py
+++ b/src/parca.py
@@ -22,6 +22,8 @@ class Parca:
     """Class representing Parca running in a container under Pebble."""
 
     _port = 7070
+    # Seconds to wait in between requests to version endpoint
+    _version_retry_wait = 3
 
     def pebble_layer(self, config) -> dict:
         """Return a Pebble layer for Parca based on the current configuration."""
@@ -59,11 +61,10 @@ class Parca:
         while True:
             try:
                 res = urllib.request.urlopen(f"http://localhost:{self._port}")
-                text = res.read().decode()
-                m = VERSION_PATTERN.search(text)
+                m = VERSION_PATTERN.search(res.read().decode())
                 return m.groups()[0]
             except Exception:
-                if retries == 3:
-                    raise
+                if retries == 2:
+                    return ""
                 retries += 1
-                time.sleep(3)
+                time.sleep(self._version_retry_wait)

--- a/src/parca.py
+++ b/src/parca.py
@@ -25,14 +25,14 @@ class Parca:
     # Seconds to wait in between requests to version endpoint
     _version_retry_wait = 3
 
-    def pebble_layer(self, config) -> dict:
+    def pebble_layer(self, config, store_config=None) -> dict:
         """Return a Pebble layer for Parca based on the current configuration."""
         return {
             "services": {
                 "parca": {
                     "override": "replace",
                     "summary": "parca",
-                    "command": parca_command_line(config),
+                    "command": parca_command_line(app_config=config, store_config=store_config),
                     "startup": "enabled",
                 }
             },
@@ -50,10 +50,7 @@ class Parca:
     @property
     def version(self) -> str:
         """Report the version of Parca."""
-        try:
-            return self._fetch_version()
-        except Exception:
-            return ""
+        return self._fetch_version()
 
     def _fetch_version(self) -> str:
         """Fetch the version from the running workload using the Parca API."""

--- a/tests/unit/test_parca.py
+++ b/tests/unit/test_parca.py
@@ -6,8 +6,10 @@ from unittest.mock import MagicMock, patch
 
 from parca import Parca
 
-MOCK_WEB_RESPONSE_V1 = b'<!doctype html><html lang="en"><head><script>window.PATH_PREFIX="",window.APP_VERSION="v0.18.0-2b08f0bd"</script><meta charset="utf-8"/><link rel="icon" href="/favicon.svg"/><meta name="viewport" content="width=device-width,initial-scale=1"/><meta name="theme-color" content="#000000"/><meta name="description" content="Open Source Infrastructure-wide continuous profiling"/><link rel="apple-touch-icon" href="/logo192.png"/><link rel="manifest" href="/manifest.json"/><title>Parca</title><script defer="defer" src="/static/js/main.e6a20ad1.js"></script><link href="/static/css/main.943f71c0.css" rel="stylesheet"></head><body class="bg-gray-50 text-gray-800 dark:bg-gray-900 dark:text-gray-200"><noscript>You need to enable JavaScript to run this app.</noscript><div id="root"></div></body></html>'
-MOCK_WEB_RESPONSE_V2 = b'<!doctype html><html lang="en"><head><script>window.PATH_PREFIX="",window.APP_VERSION="v0.18.0"</script><meta charset="utf-8"/><link rel="icon" href="/favicon.svg"/><meta name="viewport" content="width=device-width,initial-scale=1"/><meta name="theme-color" content="#000000"/><meta name="description" content="Open Source Infrastructure-wide continuous profiling"/><link rel="apple-touch-icon" href="/logo192.png"/><link rel="manifest" href="/manifest.json"/><title>Parca</title><script defer="defer" src="/static/js/main.e6a20ad1.js"></script><link href="/static/css/main.943f71c0.css" rel="stylesheet"></head><body class="bg-gray-50 text-gray-800 dark:bg-gray-900 dark:text-gray-200"><noscript>You need to enable JavaScript to run this app.</noscript><div id="root"></div></body></html>'
+# Extract from a real response that Parca issued to test the regular expression works for capturing
+# the version from the served page.
+MOCK_WEB_RESPONSE_V1 = b'<script>window.PATH_PREFIX="",window.APP_VERSION="v0.18.0-2b08f0bd"</s'
+MOCK_WEB_RESPONSE_V2 = b'<script>window.PATH_PREFIX="",window.APP_VERSION="v0.18.0"</s>'
 
 
 class TestParca(unittest.TestCase):
@@ -48,7 +50,17 @@ class TestParca(unittest.TestCase):
 
         self.assertEqual(self.parca._fetch_version(), "0.18.0")
 
-    @patch("parca.Parca._fetch_version")
+    @patch("urllib.request.urlopen")
     def test_version_fetch_raises_empty_string_response(self, fv):
         fv.side_effect = Exception
+        # Don't wait 3 seconds in between retry calls
+        self.parca._version_retry_wait = 0.1
         self.assertEqual(self.parca.version, "")
+
+    @patch("urllib.request.urlopen")
+    def test_fetch_version_retries(self, uo):
+        uo.side_effect = Exception
+        # Don't wait 3 seconds in between retry calls
+        self.parca._version_retry_wait = 0.1
+        self.parca._fetch_version()
+        self.assertEqual(uo.call_count, 3)


### PR DESCRIPTION
Adds the ability for Parca to go into "scraper only" mode and send profiles to an external Parca store, such as the Polar Signals cloud.